### PR TITLE
Handle Unicode with `std::wstring` in `as_string` and `to_string`

### DIFF
--- a/src/convert.cpp
+++ b/src/convert.cpp
@@ -23,7 +23,7 @@ namespace pyjs
         }
         else if (info == "str")
         {
-            return std::make_pair(em::val(py_ret.cast<std::string>()),false);
+            return std::make_pair(em::val(py_ret.cast<std::wstring>()),false);
         }
         else if (info == "bool")
         {
@@ -69,7 +69,7 @@ namespace pyjs
                 // 2 is object
                 case static_cast<char>(JsType::JS_STR):
                 {
-                    return py::cast(val.as<std::string>());
+                    return py::cast(val.as<std::wstring>());
                 }
                 case static_cast<char>(JsType::JS_INT):
                 {

--- a/src/export_js_proxy.cpp
+++ b/src/export_js_proxy.cpp
@@ -208,7 +208,7 @@ namespace pyjs
         m_internal.def("as_double", [](em::val* v) -> double { return v->as<double>(); });
         m_internal.def("as_float", [](em::val* v) -> float { return v->as<float>(); });
         m_internal.def("as_boolean", [](em::val* v) -> bool { return v->as<bool>(); });
-        m_internal.def("as_string", [](em::val* v) -> std::string { return v->as<std::string>(); });
+        m_internal.def("as_string", [](em::val* v) -> std::wstring { return v->as<std::wstring>(); });
 
         m_internal.def("as_numpy_array",
                        [](em::val* v) -> py::object { return typed_array_to_numpy_array(*v); });
@@ -276,13 +276,13 @@ namespace pyjs
 
 
         m_internal.def("to_string",
-                       [](em::val* v) -> std::string { return v->call<std::string>("toString"); });
+                       [](em::val* v) -> std::wstring { return v->call<std::wstring>("toString"); });
         // this class is heavy extended on the python side
         // py::class_<em::val>(m, "JsValue",  py::dynamic_attr())
         py::class_<em::val>(m, "JsValue")  //,  py::dynamic_attr())
 
-            .def(py::init([](std::string arg)
-                          { return std::unique_ptr<em::val>(new em::val(arg.c_str())); }))
+            .def(py::init([](std::wstring arg)
+                          { return std::unique_ptr<em::val>(new em::val(arg)); }))
             .def(py::init([](bool arg) { return std::unique_ptr<em::val>(new em::val(arg)); }))
 
             .def(py::init([](int arg) { return std::unique_ptr<em::val>(new em::val(arg)); }))
@@ -304,7 +304,7 @@ namespace pyjs
 
         m_internal.def("implicit_py_to_js",&implicit_py_to_js);
 
-        py::implicitly_convertible<std::string, em::val>();
+        py::implicitly_convertible<std::wstring, em::val>();
         py::implicitly_convertible<float, em::val>();
         py::implicitly_convertible<double, em::val>();
         py::implicitly_convertible<int, em::val>();


### PR DESCRIPTION
- Update `as_string` and `to_string` to return `std::wstring`
- Update `py::init` in `JsValue` to take `std::wstring`
- Update `py::implicitly_convertible` to convert `std::wstring` to `em::val`

These changes ensure that the `as_string` and `to_string` methods can handle Unicode characters in attribute values and function arguments, and that the `JsValue` class can be initialized and converted to from `std::wstring` containing Unicode characters.

Note: JavaScript uses UTF-16 encoding, which is why `std::wstring` is used in this situation. Pybind11 automatically handles the conversion between `std::wstring` and Python strings.

Uncertainty: It is unclear whether JavaScript supports non-ASCII characters in attribute names. A separate pull request may be needed to handle Unicode in attribute names if this is necessary.

This pull request was composed with the help of ChatGPT (https://openai.com/blog/chatgpt/)