### PR TITLE
Allowing to use a package url

### DIFF
--- a/include/pyjs/pre_js/load_pkg.js
+++ b/include/pyjs/pre_js/load_pkg.js
@@ -108,7 +108,7 @@ Module["bootstrap_from_empack_packed_environment"] = async function
                 pkg,
                 verbose
             ) {
-            let package_url = `${package_tarballs_root_url}/${pkg.filename}`
+            let package_url = pkg?.url ? pkg.url :`${package_tarballs_root_url}/${pkg.filename}`
             if (verbose) {
                 console.log(`!!fetching pkg ${pkg.name} from ${package_url}`)
             }
@@ -126,7 +126,7 @@ Module["bootstrap_from_empack_packed_environment"] = async function
         
         async function bootstrap_python(prefix, package_tarballs_root_url, python_package, verbose) {
             // fetch python package
-            let python_package_url = `${package_tarballs_root_url}/${python_package.filename}`
+            let python_package_url = python_package?.url ? python_package.url : `${package_tarballs_root_url}/${python_package.filename}`
         
             if (verbose) {
                 console.log(`fetching python package from ${python_package_url}`)

--- a/include/pyjs/pre_js/load_pkg.js
+++ b/include/pyjs/pre_js/load_pkg.js
@@ -108,7 +108,7 @@ Module["bootstrap_from_empack_packed_environment"] = async function
                 pkg,
                 verbose
             ) {
-            let package_url = pkg?.url ? pkg.url :`${package_tarballs_root_url}/${pkg.filename}`
+            const package_url = pkg?.url ?? `${package_tarballs_root_url}/${pkg.filename}`;
             if (verbose) {
                 console.log(`!!fetching pkg ${pkg.name} from ${package_url}`)
             }
@@ -126,7 +126,7 @@ Module["bootstrap_from_empack_packed_environment"] = async function
         
         async function bootstrap_python(prefix, package_tarballs_root_url, python_package, verbose) {
             // fetch python package
-            let python_package_url = python_package?.url ? python_package.url : `${package_tarballs_root_url}/${python_package.filename}`
+            const python_package_url = python_package?.url ?? `${package_tarballs_root_url}/${python_package.filename}`;
         
             if (verbose) {
                 console.log(`fetching python package from ${python_package_url}`)


### PR DESCRIPTION
This PR is the part of the solution of https://github.com/QuantStack/qs.ai/issues/28

This is updated version of https://github.com/emscripten-forge/pyjs/pull/69 , but packages will be able to use a full url to be downloaded. It will be expected that `empack_env_meta.json` file will allow having `url` for packages and if it is present then this url will be used to download a certain package. If not, the default behavior will be taken.

This PR should be used together with https://github.com/jupyterlite/xeus/pull/120