### PR TITLE
Separate initiating python phases for xeus-python

### DIFF
--- a/include/pyjs/pre_js/load_pkg.js
+++ b/include/pyjs/pre_js/load_pkg.js
@@ -331,7 +331,6 @@ Module["init_python_phases"] = async function (
     if(verbose) {
         console.log('Turn on support for running python code for xeus-python');
     }
-    if(verbose){console.log("start init_phase_1");}
     await Module.init_phase_1(prefix, python_version, verbose);
     Module.init_phase_2(prefix, python_version, verbose);
 }

--- a/include/pyjs/pre_js/load_pkg.js
+++ b/include/pyjs/pre_js/load_pkg.js
@@ -321,3 +321,17 @@ Module["bootstrap_from_empack_packed_environment"] = async function
         console.error(e);
     }
 }
+
+Module["init_python_phases"] = async function (   
+    python_version = [3,11],
+    prefix,
+    verbose = true
+) 
+{
+    if(verbose) {
+        console.log('Turn on support for running python code for xeus-python');
+    }
+    if(verbose){console.log("start init_phase_1");}
+    await Module.init_phase_1(prefix, python_version, verbose);
+    Module.init_phase_2(prefix, python_version, verbose);
+}


### PR DESCRIPTION
This PR is the part of solution where conda packages should be donwloaded and saved by using JavaScript. Since xeus-python requires python, it has been decided to limit of using pyjs and call python initialization for this kernel only