### PR TITLE
Rename exception extraction function

### DIFF
--- a/src/export_js_module.cpp
+++ b/src/export_js_module.cpp
@@ -93,7 +93,7 @@ namespace pyjs
     }
 
 
-    std::string get_exception_message(int exceptionPtr)
+    std::string extract_exception_message(int exceptionPtr)
     {
         auto ptr = reinterpret_cast<std::exception *>(exceptionPtr);
 
@@ -140,7 +140,7 @@ namespace pyjs
                                                                    { std::cout << val; }));
 
 
-        em::function("get_exception_message", &get_exception_message);
+        em::function("extract_exception_message", &extract_exception_message);
 
     }
 


### PR DESCRIPTION
This causes conflicts with xeus-lite https://github.com/jupyter-xeus/xeus-lite/blob/d9279c0983b738ff6847a5edab6246bbd903eca6/include/xeus-lite/xembind.hpp#L78 preventing xeus-python to work