### PR TITLE
Declare `_lock` earlier

### DIFF
--- a/include/pyjs/pre_js/dynload/dynload.js
+++ b/include/pyjs/pre_js/dynload/dynload.js
@@ -1,6 +1,8 @@
 
+let _lock;
+
 function createLock() {
-    let _lock = Promise.resolve();
+    _lock = Promise.resolve();
 
     async function acquireLock() {
         const old_lock = _lock;


### PR DESCRIPTION
In `dynload.js`, declare `_lock` earlier, outside fof the `createLock` function.

This came up in my `xeus-runner` experiments to run `xeus-python` and `xeus-shakespearelang` in both a web worker and the main UI thread, solving and downloading packages using `mambajs`. Before this change both kernels worked fine in the web worker but not in the main UI thread which failed with `ReferenceError: _lock is not defined` at the first mention of `_lock` just below the `createLock` function. I suppose that there is some difference in parsing the JS code after loading in the main UI thread, the `import` code is necessarily different for this compared to in the web worker.

The fix simply moves the `let _lock` declaration to be outside of and above the `createLock` function. After this I performed the following steps locally:

1. Rebuilt the `pyjs` emscripten-forge recipe using this branch as `4.0.3 build 1`.
2. Rebuilt the `xeus-python` emscripten-forge recipe as `0.18.3 builld 1` (not `0.19.0` due to the `mambajs` problem using 0.19.0 that we have discussed elsewhere).
3. Rebuilt the `xeus-pywrap` emscripten-forge recipe as `0.1.1 build 2`.

then using these new packages both `xeus-python` and `xeus-shakespearelang` work in `xeus-runner` in the main UI thread.